### PR TITLE
Allow to run raw command

### DIFF
--- a/src/IpfsConnector.ts
+++ b/src/IpfsConnector.ts
@@ -699,7 +699,6 @@ export class IpfsConnector extends EventEmitter {
         return this.staticGetPorts();
     }
 
-
     /**
      *
      * @param ports
@@ -736,5 +735,30 @@ export class IpfsConnector extends EventEmitter {
                 });
             }
         );
+    }
+
+    /**
+     * Run a raw command through the command line on the local daemon.
+     * @param args
+     * @returns {Bluebird<U>}
+     */
+    public runCommand(args: string) {
+        return this.checkExecutable()
+            .then((execPath) => {
+                return new Promise((resolve, reject) => {
+                    childProcess.exec(`${execPath} ${args}`,
+                      {env: this.options.extra.env},
+                      (error, stdout, stderr) => {
+                          if (error) {
+                              this.logger.error(error);
+                              return reject(error);
+                          }
+                          if (stderr) {
+                              this.logger.warn(stderr);
+                          }
+                          return resolve(stdout);
+                      });
+                });
+            });
     }
 }

--- a/tests.ts
+++ b/tests.ts
@@ -322,6 +322,19 @@ describe('IpfsConnector', function () {
         return instance.runCommand('id')
           .then((stdout: string) => {
               expect(stdout).to.exist;
+          })
+          .catch(() => {
+            throw new Error('Should not fail');
+          });
+    });
+
+    it('fail running a raw cli commands properly', function () {
+        return instance.runCommand('doesnotexist')
+          .then(() => {
+              throw new Error('Should not succed');
+          })
+          .catch((stderr: string) => {
+              expect(stderr).to.exist;
           });
     });
 

--- a/tests.ts
+++ b/tests.ts
@@ -318,6 +318,13 @@ describe('IpfsConnector', function () {
           });
     });
 
+    it('run raw cli commands', function () {
+        return instance.runCommand('id')
+          .then((stdout: string) => {
+              expect(stdout).to.exist;
+          });
+    });
+
     it('doesn`t throw when calling multiple start', function () {
         return IpfsConnector.getInstance().start().then(() => IpfsConnector.getInstance().start());
     });
@@ -334,7 +341,6 @@ describe('IpfsConnector', function () {
     it('removes ipfs binary file', function (done) {
         instance.downloadManager.deleteBin().then(() => done());
     });
-
 
     after(function (done) {
         instance.stop().then(() => {


### PR DESCRIPTION
Hello,

I thought I needed that for my project (or maybe not, I'll see ...) so here it is.

This allow to run arbitrary ipfs command through the command line instead of through the API. To avoid command injection, it use child_process.spawn instead of child_process.exec.