### PR TITLE
expose the daemon status and add a STATUS_UPDATE event

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
 /// <reference path="typings/main.d.ts"/>
-export { IpfsConnector } from './src/IpfsConnector';
+export { IpfsConnector, ConnectorState } from './src/IpfsConnector';
 export { IpfsBin } from './src/IpfsBin';
 export { events as ipfsEvents } from './src/constants';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const events = {
     SERVICE_FAILED: 'SERVICE_FAILED',
     IPFS_INITING: 'IPFS_INITING',
     IPFS_INIT: 'init',
+    STATUS_UPDATE: 'STATUS_UPDATE',
     ERROR: 'error'
 };
 


### PR DESCRIPTION
This PR:
- expose the daemon's status for an easier integration in an application
- add a new `STATUS_UPDATE` event to be able to react on a status change.